### PR TITLE
Add identifier nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,23 @@ ADD genres/*.go /genres-rw-neo4j/genres/
 RUN apk add --update bash \
   && apk --update add git bzr \
   && apk --update add go \
+  && cd genres-rw-neo4j \
+  && git fetch origin 'refs/tags/*:refs/tags/*' \
+  && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
+  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+  && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && REVISION="revision=$(git rev-parse HEAD)" \
+  && BUILDER="builder=$(go version)" \
+  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && cd .. \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/genres-rw-neo4j" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv genres-rw-neo4j/* $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \
-  && go build \
+  && go build -ldflags="${LDFLAGS}" \
   && mv genres-rw-neo4j /app \
   && apk del go git bzr \
   && rm -rf $GOPATH /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 
 FROM alpine:3.3
 
-ADD *.go /genres-rw-neo4j/
-ADD genres/*.go /genres-rw-neo4j/genres/
+ADD . /genres-rw-neo4j/
 
 RUN apk add --update bash \
-  && apk --update add git bzr \
-  && apk --update add go \
+  && apk --update add git go bzr \
   && cd genres-rw-neo4j \
   && git fetch origin 'refs/tags/*:refs/tags/*' \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
@@ -23,6 +21,7 @@ RUN apk add --update bash \
   && mv genres-rw-neo4j/* $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \
+  && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \
   && mv genres-rw-neo4j /app \
   && apk del go git bzr \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NB: the default batchSize is much higher than the throughput the instance data i
 ## Endpoints
 /genres/{uuid}
 ### PUT
-The only mandatory field is the uuid, and the uuid in the body must match the one used on the path.
+"The only mandatory fields are the uuid, the prefLabel and the alternativeIdentifier uuids (because the uuid is also listed in the alternativeIdentifier uuids list)."
 
 Every request results in an attempt to update that genre: unlike with GraphDB there is no check on whether the genre already exists and whether there are any changes between what's there and what's being written. We just do a MERGE which is Neo4j for create if not there, update if it is there.
 
@@ -50,7 +50,9 @@ We run queries in batches. If a batch fails, all failing requests will get a 500
 Invalid json body input, or uuids that don't match between the path and the body will result in a 400 bad request response.
 
 Example:
-`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/genres/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","canonicalName":"Obituary","tmeIdentifier":"MTE3-U3ViamVjdHM=","type":"Genre"}'`
+`curl -XPUT -H "X-Request-Id: 123" -H "Content-Type: application/json" localhost:8080/genres/bba39990-c78d-3629-ae83-808c333c6dbc --data '{"uuid":"bba39990-c78d-3629-ae83-808c333c6dbc","prefLabel":"Obituary", "alternativeIdentifiers":{"TME":["MTE3-U3ViamVjdHM="],"uuids": ["bba39990-c78d-3629-ae83-808c333c6dbc","6a2a0170-6afa-4bcc-b427-430268d2ac50"],"factsetIdentifier":"asdasd","leiCode":"baz","type":"Genre"}}'`
+
+The type field is not currently validated - instead, the Topic Writer writes type Topic and its parent types (Concept and Thing) as labels for the Topic.
 
 ### GET
 The internal read should return what got written

--- a/genres/genres_service.go
+++ b/genres/genres_service.go
@@ -20,10 +20,10 @@ func NewCypherGenresService(cypherRunner neoutils.CypherRunner, indexManager neo
 
 func (s service) Initialise() error {
 	return neoutils.EnsureConstraints(s.indexManager, map[string]string{
-		"Thing":   "uuid",
-		"Concept": "uuid",
-		"Classification": "uuid",
-		"Genre": "uuid",
+		"Thing":             "uuid",
+		"Concept":           "uuid",
+		"Classification":    "uuid",
+		"Genre":             "uuid",
 		"FactsetIdentifier": "value",
 		"TMEIdentifier":     "value",
 		"UPPIdentifier":     "value"})

--- a/genres/genres_service.go
+++ b/genres/genres_service.go
@@ -2,7 +2,7 @@ package genres
 
 import (
 	"encoding/json"
-
+	"fmt"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 )
@@ -23,16 +23,22 @@ func (s service) Initialise() error {
 		"Thing":   "uuid",
 		"Concept": "uuid",
 		"Classification": "uuid",
-		"Genre": "uuid"})
+		"Genre": "uuid",
+		"FactsetIdentifier": "value",
+		"TMEIdentifier":     "value",
+		"UPPIdentifier":     "value"})
 }
 
 func (s service) Read(uuid string) (interface{}, bool, error) {
 	results := []Genre{}
 
 	query := &neoism.CypherQuery{
-		Statement: `MATCH (n:Genre {uuid:{uuid}}) return n.uuid
-		as uuid, n.canonicalName as canonicalName,
-		n.tmeIdentifier as tmeIdentifier`,
+		Statement: `MATCH (n:Genre {uuid:{uuid}})
+OPTIONAL MATCH (upp:UPPIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (fs:FactsetIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (tme:TMEIdentifier)-[:IDENTIFIES]->(n)
+OPTIONAL MATCH (lei:LegalEntityIdentifier)-[:IDENTIFIES]->(n)
+return distinct n.uuid as uuid, n.prefLabel as prefLabel, labels(n) as types, {uuids:collect(distinct upp.value), TME:collect(distinct tme.value), factsetIdentifier:fs.value, leiCode:lei.value} as alternativeIdentifiers`,
 		Parameters: map[string]interface{}{
 			"uuid": uuid,
 		},
@@ -54,22 +60,20 @@ func (s service) Read(uuid string) (interface{}, bool, error) {
 
 func (s service) Write(thing interface{}) error {
 
-	sub := thing.(Genre)
+	genre := thing.(Genre)
 
-	params := map[string]interface{}{
-		"uuid": sub.UUID,
+	//cleanUP all the previous IDENTIFIERS referring to that uuid
+	deletePreviousIdentifiersQuery := &neoism.CypherQuery{
+		Statement: `MATCH (t:Thing {uuid:{uuid}})
+		OPTIONAL MATCH (t)<-[iden:IDENTIFIES]-(i)
+		DELETE iden, i`,
+		Parameters: map[string]interface{}{
+			"uuid": genre.UUID,
+		},
 	}
 
-	if sub.CanonicalName != "" {
-		params["canonicalName"] = sub.CanonicalName
-		params["prefLabel"] = sub.CanonicalName
-	}
-
-	if sub.TmeIdentifier != "" {
-		params["tmeIdentifier"] = sub.TmeIdentifier
-	}
-
-	query := &neoism.CypherQuery{
+	//create-update node for TOPIC
+	createTopicQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid: {uuid}})
 					set n={allprops}
 					set n :Concept
@@ -77,29 +81,68 @@ func (s service) Write(thing interface{}) error {
 					set n :Genre
 		`,
 		Parameters: map[string]interface{}{
-			"uuid":     sub.UUID,
-			"allprops": params,
+			"uuid": genre.UUID,
+			"allprops": map[string]interface{}{
+				"uuid":      genre.UUID,
+				"prefLabel": genre.PrefLabel,
+			},
 		},
 	}
 
-	return s.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	queryBatch := []*neoism.CypherQuery{deletePreviousIdentifiersQuery, createTopicQuery}
 
+	//ADD all the IDENTIFIER nodes and IDENTIFIES relationships
+	if genre.AlternativeIdentifiers.FactsetIdentifier != "" {
+		factsetIdentifierQuery := createNewIdentifierQuery(genre.UUID, factsetIdentifierLabel, genre.AlternativeIdentifiers.FactsetIdentifier)
+		queryBatch = append(queryBatch, factsetIdentifierQuery)
+	}
+
+	if genre.AlternativeIdentifiers.LeiCode != "" {
+		leiCodeIdentifierQuery := createNewIdentifierQuery(genre.UUID, leiIdentifierLabel, genre.AlternativeIdentifiers.LeiCode)
+		queryBatch = append(queryBatch, leiCodeIdentifierQuery)
+	}
+
+	for _, alternativeUUID := range genre.AlternativeIdentifiers.TME {
+		alternativeIdentifierQuery := createNewIdentifierQuery(genre.UUID, tmeIdentifierLabel, alternativeUUID)
+		queryBatch = append(queryBatch, alternativeIdentifierQuery)
+	}
+
+	for _, alternativeUUID := range genre.AlternativeIdentifiers.UUIDS {
+		alternativeIdentifierQuery := createNewIdentifierQuery(genre.UUID, uppIdentifierLabel, alternativeUUID)
+		queryBatch = append(queryBatch, alternativeIdentifierQuery)
+	}
+	return s.cypherRunner.CypherBatch(queryBatch)
+
+}
+
+func createNewIdentifierQuery(uuid string, identifierLabel string, identifierValue string) *neoism.CypherQuery {
+	statementTemplate := fmt.Sprintf(`MERGE (t:Thing {uuid:{uuid}})
+					CREATE (i:Identifier {value:{value}})
+					MERGE (t)<-[:IDENTIFIES]-(i)
+					set i : %s `, identifierLabel)
+	query := &neoism.CypherQuery{
+		Statement: statementTemplate,
+		Parameters: map[string]interface{}{
+			"uuid":  uuid,
+			"value": identifierValue,
+		},
+	}
+	return query
 }
 
 func (s service) Delete(uuid string) (bool, error) {
 	clearNode := &neoism.CypherQuery{
 		Statement: `
 			MATCH (s:Thing {uuid: {uuid}})
+			OPTIONAL MATCH (t)<-[iden:IDENTIFIES]-(i:Identifier)
 			REMOVE s:Concept
 			REMOVE s:Classification
 			REMOVE s:Genre
-			SET s={props}
+			DELETE iden, i
+			SET s={uuid:{uuid}}
 		`,
 		Parameters: map[string]interface{}{
 			"uuid": uuid,
-			"props": map[string]interface{}{
-				"uuid": uuid,
-			},
 		},
 		IncludeStats: true,
 	}

--- a/genres/genres_service_test.go
+++ b/genres/genres_service_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	genreUUID = "12345"
-	newGenreUUID = "123456"
+	genreUUID            = "12345"
+	newGenreUUID         = "123456"
 	tmeID                = "TME_ID"
 	newTmeID             = "NEW_TME_ID"
 	fsetID               = "fset_ID"

--- a/genres/genres_service_test.go
+++ b/genres/genres_service_test.go
@@ -4,100 +4,158 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
 )
 
-var genresDriver baseftrwapp.Service
+const (
+	genreUUID = "12345"
+	newGenreUUID = "123456"
+	tmeID                = "TME_ID"
+	newTmeID             = "NEW_TME_ID"
+	fsetID               = "fset_ID"
+	leiCodeID            = "leiCode"
+	prefLabel            = "Test"
+	specialCharPrefLabel = "Test 'special chars"
+)
 
-func TestDelete(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-
-	genresDriver = getGenresCypherDriver(t)
-
-	genreToDelete := Genre{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(genreToDelete), "Failed to write genre")
-
-	found, err := genresDriver.Delete(uuid)
-	assert.True(found, "Didn't manage to delete genre for uuid %", uuid)
-	assert.NoError(err, "Error deleting genre for uuid %s", uuid)
-
-	p, found, err := genresDriver.Read(uuid)
-
-	assert.Equal(Genre{}, p, "Found genre %s who should have been deleted", p)
-	assert.False(found, "Found genre for uuid %s who should have been deleted", uuid)
-	assert.NoError(err, "Error trying to find genre for uuid %s", uuid)
-}
-
-func TestCreateAllValuesPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	genresDriver = getGenresCypherDriver(t)
-
-	genreToWrite := Genre{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
-
-	readGenreForUUIDAndCheckFieldsMatch(t, uuid, genreToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestCreateHandlesSpecialCharacters(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	genresDriver = getGenresCypherDriver(t)
-
-	genreToWrite := Genre{UUID: uuid, CanonicalName: "Test 'special chars", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
-
-	readGenreForUUIDAndCheckFieldsMatch(t, uuid, genreToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestCreateNotAllValuesPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	genresDriver = getGenresCypherDriver(t)
-
-	genreToWrite := Genre{UUID: uuid, CanonicalName: "Test"}
-
-	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
-
-	readGenreForUUIDAndCheckFieldsMatch(t, uuid, genreToWrite)
-
-	cleanUp(t, uuid)
-}
-
-func TestUpdateWillRemovePropertiesNoLongerPresent(t *testing.T) {
-	assert := assert.New(t)
-	uuid := "12345"
-	genresDriver = getGenresCypherDriver(t)
-
-	genreToWrite := Genre{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
-	readGenreForUUIDAndCheckFieldsMatch(t, uuid, genreToWrite)
-
-	updatedGenre := Genre{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(updatedGenre), "Failed to write updated genre")
-	readGenreForUUIDAndCheckFieldsMatch(t, uuid, updatedGenre)
-
-	cleanUp(t, uuid)
-}
+var defaultTypes = []string{"Thing", "Concept", "Classification", "Genre"}
 
 func TestConnectivityCheck(t *testing.T) {
 	assert := assert.New(t)
-	genresDriver = getGenresCypherDriver(t)
+	genresDriver := getGenresCypherDriver(t)
 	err := genresDriver.Check()
 	assert.NoError(err, "Unexpected error on connectivity check")
+}
+
+func TestPrefLabelIsCorrectlyWritten(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{UUIDS: []string{genreUUID}}
+	genreToWrite := Genre{UUID: genreUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	err := genresDriver.Write(genreToWrite)
+	assert.NoError(err, "ERROR happened during write time")
+
+	storedGenre, found, err := genresDriver.Read(genreUUID)
+	assert.NoError(err, "ERROR happened during read time")
+	assert.Equal(true, found)
+	assert.NotEmpty(storedGenre)
+
+	assert.Equal(prefLabel, storedGenre.(Genre).PrefLabel, "PrefLabel should be "+prefLabel)
+	cleanUp(assert, genreUUID, genresDriver)
+}
+
+func TestPrefLabelSpecialCharactersAreHandledByCreate(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{genreUUID}}
+	genreToWrite := Genre{UUID: genreUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
+
+	//add default types that will be automatically added by the writer
+	genreToWrite.Types = defaultTypes
+	//check if genreToWrite is the same with the one inside the DB
+	readGenreForUUIDAndCheckFieldsMatch(assert, genresDriver, genreUUID, genreToWrite)
+	cleanUp(assert, genreUUID, genresDriver)
+}
+
+func TestCreateCompleteGenreWithPropsAndIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{genreUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	genreToWrite := Genre{UUID: genreUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
+
+	//add default types that will be automatically added by the writer
+	genreToWrite.Types = defaultTypes
+	//check if genreToWrite is the same with the one inside the DB
+	readGenreForUUIDAndCheckFieldsMatch(assert, genresDriver, genreUUID, genreToWrite)
+	cleanUp(assert, genreUUID, genresDriver)
+}
+
+func TestUpdateWillRemovePropertiesAndIdentifiersNoLongerPresent(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	allAlternativeIdentifiers := alternativeIdentifiers{TME: []string{}, UUIDS: []string{genreUUID}, FactsetIdentifier: fsetID, LeiCode: leiCodeID}
+	genreToWrite := Genre{UUID: genreUUID, PrefLabel: prefLabel, AlternativeIdentifiers: allAlternativeIdentifiers}
+
+	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
+	//add default types that will be automatically added by the writer
+	genreToWrite.Types = defaultTypes
+	readGenreForUUIDAndCheckFieldsMatch(assert, genresDriver, genreUUID, genreToWrite)
+
+	tmeAlternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{genreUUID}}
+	updatedGenre := Genre{UUID: genreUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: tmeAlternativeIdentifiers}
+
+	assert.NoError(genresDriver.Write(updatedGenre), "Failed to write updated genre")
+	//add default types that will be automatically added by the writer
+	updatedGenre.Types = defaultTypes
+	readGenreForUUIDAndCheckFieldsMatch(assert, genresDriver, genreUUID, updatedGenre)
+
+	cleanUp(assert, genreUUID, genresDriver)
+}
+
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	alternativeIdentifiers := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{genreUUID}}
+	genreToDelete := Genre{UUID: genreUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIdentifiers}
+
+	assert.NoError(genresDriver.Write(genreToDelete), "Failed to write genre")
+
+	found, err := genresDriver.Delete(genreUUID)
+	assert.True(found, "Didn't manage to delete genre for uuid %", genreUUID)
+	assert.NoError(err, "Error deleting genre for uuid %s", genreUUID)
+
+	p, found, err := genresDriver.Read(genreUUID)
+
+	assert.Equal(Genre{}, p, "Found genre %s who should have been deleted", p)
+	assert.False(found, "Found genre for uuid %s who should have been deleted", genreUUID)
+	assert.NoError(err, "Error trying to find genre for uuid %s", genreUUID)
+}
+
+func TestCount(t *testing.T) {
+	assert := assert.New(t)
+	genresDriver := getGenresCypherDriver(t)
+
+	alternativeIds := alternativeIdentifiers{TME: []string{tmeID}, UUIDS: []string{genreUUID}}
+	genreOneToCount := Genre{UUID: genreUUID, PrefLabel: prefLabel, AlternativeIdentifiers: alternativeIds}
+
+	assert.NoError(genresDriver.Write(genreOneToCount), "Failed to write genre")
+
+	nr, err := genresDriver.Count()
+	assert.Equal(1, nr, "Should be 1 genres in DB - count differs")
+	assert.NoError(err, "An unexpected error occurred during count")
+
+	newAlternativeIds := alternativeIdentifiers{TME: []string{newTmeID}, UUIDS: []string{newGenreUUID}}
+	genreTwoToCount := Genre{UUID: newGenreUUID, PrefLabel: specialCharPrefLabel, AlternativeIdentifiers: newAlternativeIds}
+
+	assert.NoError(genresDriver.Write(genreTwoToCount), "Failed to write genre")
+
+	nr, err = genresDriver.Count()
+	assert.Equal(2, nr, "Should be 2 genres in DB - count differs")
+	assert.NoError(err, "An unexpected error occurred during count")
+
+	cleanUp(assert, genreUUID, genresDriver)
+	cleanUp(assert, newGenreUUID, genresDriver)
+}
+
+func readGenreForUUIDAndCheckFieldsMatch(assert *assert.Assertions, genresDriver service, uuid string, expectedGenre Genre) {
+
+	storedGenre, found, err := genresDriver.Read(uuid)
+
+	assert.NoError(err, "Error finding genre for uuid %s", uuid)
+	assert.True(found, "Didn't find genre for uuid %s", uuid)
+	assert.Equal(expectedGenre, storedGenre, "genres should be the same")
 }
 
 func getGenresCypherDriver(t *testing.T) service {
@@ -112,42 +170,7 @@ func getGenresCypherDriver(t *testing.T) service {
 	return NewCypherGenresService(neoutils.StringerDb{db}, db)
 }
 
-func readGenreForUUIDAndCheckFieldsMatch(t *testing.T, uuid string, expectedgenre Genre) {
-	assert := assert.New(t)
-	storedGenre, found, err := genresDriver.Read(uuid)
-
-	assert.NoError(err, "Error finding genre for uuid %s", uuid)
-	assert.True(found, "Didn't find genre for uuid %s", uuid)
-	assert.Equal(expectedgenre, storedGenre, "genres should be the same")
-}
-
-func TestWritePrefLabelIsAlsoWrittenAndIsEqualToName(t *testing.T) {
-	assert := assert.New(t)
-	genresDriver := getGenresCypherDriver(t)
-	uuid := "12345"
-	genreToWrite := Genre{UUID: uuid, CanonicalName: "Test", TmeIdentifier: "TME_ID"}
-
-	assert.NoError(genresDriver.Write(genreToWrite), "Failed to write genre")
-
-	result := []struct {
-		PrefLabel string `json:"t.prefLabel"`
-	}{}
-
-	getPrefLabelQuery := &neoism.CypherQuery{
-		Statement: `
-				MATCH (t:Genre {uuid:"12345"}) RETURN t.prefLabel
-				`,
-		Result: &result,
-	}
-
-	err := genresDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getPrefLabelQuery})
-	assert.NoError(err)
-	assert.Equal("Test", result[0].PrefLabel, "PrefLabel should be 'Test")
-	cleanUp(t, uuid)
-}
-
-func cleanUp(t *testing.T, uuid string) {
-	assert := assert.New(t)
+func cleanUp(assert *assert.Assertions, uuid string, genresDriver service) {
 	found, err := genresDriver.Delete(uuid)
 	assert.True(found, "Didn't manage to delete genre for uuid %", uuid)
 	assert.NoError(err, "Error deleting genre for uuid %s", uuid)

--- a/genres/model.go
+++ b/genres/model.go
@@ -2,10 +2,24 @@ package genres
 
 type Genre struct {
 	UUID          string `json:"uuid"`
-	CanonicalName string `json:"canonicalName"`
-	TmeIdentifier string `json:"tmeIdentifier,omitempty"`
-	Type          string `json:"type,omitempty"`
+	PrefLabel              string                 `json:"prefLabel"`
+	AlternativeIdentifiers alternativeIdentifiers `json:"alternativeIdentifiers"`
+	Types                  []string               `json:"types,omitempty"`
 }
+
+type alternativeIdentifiers struct {
+	TME               []string `json:"TME,omitempty"`
+	FactsetIdentifier string   `json:"factsetIdentifier,omitempty"`
+	LeiCode           string   `json:"leiCode,omitempty"`
+	UUIDS             []string `json:"uuids"`
+}
+
+const (
+	factsetIdentifierLabel = "FactsetIdentifier"
+	leiIdentifierLabel     = "LegalEntityIdentifier"
+	tmeIdentifierLabel     = "TMEIdentifier"
+	uppIdentifierLabel     = "UPPIdentifier"
+)
 
 type GenreLink struct {
 	ApiUrl string `json:"apiUrl"`

--- a/genres/model.go
+++ b/genres/model.go
@@ -1,7 +1,7 @@
 package genres
 
 type Genre struct {
-	UUID          string `json:"uuid"`
+	UUID                   string                 `json:"uuid"`
 	PrefLabel              string                 `json:"prefLabel"`
 	AlternativeIdentifiers alternativeIdentifiers `json:"alternativeIdentifiers"`
 	Types                  []string               `json:"types,omitempty"`

--- a/main.go
+++ b/main.go
@@ -6,12 +6,12 @@ import (
 	"os"
 
 	"github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp"
+	"github.com/Financial-Times/genres-rw-neo4j/genres"
 	"github.com/Financial-Times/go-fthealth/v1a"
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	log "github.com/Sirupsen/logrus"
 	"github.com/jawher/mow.cli"
 	"github.com/jmcvetta/neoism"
-	"github.com/Financial-Times/genres-rw-neo4j/genres"
 )
 
 func init() {


### PR DESCRIPTION
Changes include for the genres-rw-neo4j:
- Make all the alternative ids Identifier nodes
- Only use prefLabel
- Add build-info
- Update the RW for the new json model - coming out from the transformer
